### PR TITLE
[Fix] IOS 메모리 누수 해결 Method 추가

### DIFF
--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -34,6 +34,9 @@ class NaverMapController {
 
   Future<dynamic> _handleMethodCall(MethodCall call) async {
     switch (call.method) {
+      case 'map#clearMapView':
+        clearMapView();
+        break;
       case 'marker#onTap':
         String markerId = call.arguments['markerId'];
         int? iconWidth = call.arguments['iconWidth'] as int?;
@@ -89,6 +92,14 @@ class NaverMapController {
         }
         break;
     }
+  }
+
+  /// 네이버 맵 위젯의 메모리 할당을 해제합니다
+  /// 현재, IOS 기기에서 네이버 맵 인스턴스 해제가 되지 않는 이슈가 있어, 이 Method는 IOS 플랫폼에서만 지원 합니다.
+  /// (안드로이드 기기는 자동 해제됩니다.)
+  /// Ex) Platform.isIOS 조건문 이용
+  Future<void> clearMapView() async {
+    await _channel.invokeMethod<List<dynamic>>('map#clearMapView');
   }
 
   Future<void> _updateMapOptions(Map<String, dynamic> optionsUpdate) async {


### PR DESCRIPTION
현재 IOS 기기에서 네이버 맵 인스턴스가 자동으로 해제되지 않아, Memory Leak 문제를 겪고 있습니다.

빠른 해결을 위해 NaverMapController Class 내 mapView, navermap 등 멤버 변수의 nil 처리 method를 추가했습니다.

StatefulWidget 내 dispose 함수에서 navermapcontroller 객체의 clearMapView method를 호출하면 메모리 누수 문제를 해결할 수 있습니다.

ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ

NaverMapController 클래스 내 mapView와 navermap 변수에 옵셔널을 추가하고, 참조 부분은 unwrapping을 하였습니다.
이후, 메소드를 호출하면 각 변수에 nil을 할당하여 메모리를 수동 해제하였습니다.

하지만, 옵셔널을 추가한 부분으로 안정성이 떨어질 수 있습니다. (null 참조)
전체 인스턴스 해제가 아니므로 Memory Leak가 다소 나타나지만 90% 정도 차이가 줄었습니다. 