### PR TITLE
[Fix] null-aware 오류 수정

### DIFF
--- a/lib/src/circle_overlay.dart
+++ b/lib/src/circle_overlay.dart
@@ -93,9 +93,7 @@ class CircleOverlay {
       );
 
   Map<String, dynamic> _toJson() {
-    assert(overlayId != null);
-    assert(center != null);
-    assert(radius != null);
+    assert(overlayId.isNotEmpty);
 
     final Map<String, dynamic> json = {};
 
@@ -106,7 +104,7 @@ class CircleOverlay {
     }
 
     addIfPresent('overlayId', overlayId);
-    addIfPresent('center', center?._toJson());
+    addIfPresent('center', center._toJson());
     addIfPresent('radius', radius);
     addIfPresent('color', color?.value);
     addIfPresent('outlineColor', outlineColor?.value);
@@ -126,7 +124,7 @@ List<Map<String, dynamic>>? _serializeCircleSet(
 }
 
 Map<String, CircleOverlay> _keyByCircleId(Iterable<CircleOverlay> circles) {
-  if (circles == null) return {};
+  if (circles.isEmpty) return {};
   return Map<String, CircleOverlay>.fromEntries(circles
       .map((e) => MapEntry<String, CircleOverlay>(e.overlayId, e.clone())));
 }

--- a/lib/src/marker.dart
+++ b/lib/src/marker.dart
@@ -203,8 +203,7 @@ class Marker {
       this.subCaptionRequestedWidth});
 
   Map<String, dynamic> _toJson() {
-    assert(markerId != null);
-    assert(position != null);
+    assert(markerId.isNotEmpty);
 
     final Map<String, dynamic> json = <String, dynamic>{};
 
@@ -217,7 +216,7 @@ class Marker {
     addIfPresent('markerId', markerId);
     addIfPresent('alpha', alpha);
     addIfPresent('flat', flat);
-    addIfPresent('position', position?._toJson());
+    addIfPresent('position', position._toJson());
     addIfPresent('captionText', captionText);
     addIfPresent('captionTextSize', captionTextSize);
     addIfPresent('captionColor', captionColor?.value);
@@ -369,7 +368,7 @@ List<Map<String, dynamic>>? _serializeMarkerSet(Iterable<Marker?>? markers) {
 }
 
 Map<String, Marker> _keyByMarkerId(Iterable<Marker> markers) {
-  if (markers == null) {
+  if (markers.isEmpty) {
     return <String, Marker>{};
   }
   return Map<String, Marker>.fromEntries(markers.map((Marker marker) =>

--- a/lib/src/naver_map.dart
+++ b/lib/src/naver_map.dart
@@ -362,7 +362,7 @@ class _NaverMapState extends State<NaverMap> {
   void _updatePolylineOverlay() async {
     final NaverMapController controller = await _controller.future;
     controller._updatePolylineOverlay(_PolylineOverlayUpdates.from(
-        _polylines.values?.toSet(), widget.polylineOverlays.toSet()));
+        _polylines.values.toSet(), widget.polylineOverlays.toSet()));
     _polylines = _keyByPolylineOverlayId(widget.polylineOverlays);
   }
 


### PR DESCRIPTION
<img width="253" alt="스크린샷 2021-10-05 오후 2 28 07" src="https://user-images.githubusercontent.com/8438478/135965546-c12490f3-5256-48fd-a41a-a1d2a7954431.png">
<img width="822" alt="스크린샷 2021-10-05 오후 2 31 40" src="https://user-images.githubusercontent.com/8438478/135965863-67b18297-c733-436c-ac1d-270016ab991a.png">
일부 변수들이 현재 null safety 적용 이후 null 이 들어갈 수 없게 되어있음에도 addIfPresent, assert등에서 null을 체크하여 빌드 또는 실행시에  다음과 같은 오류가 발생하고있습니다.

`Operand of null-aware operation '?.' has type 'LatLng' which excludes null`

일부 null safety가 미흡하게 처리된 부분을 수정하여 pull request 합니다.